### PR TITLE
 chore: Add @w.i.p tag to Kafka scenario 

### DIFF
--- a/features/V3/message_provider.feature
+++ b/features/V3/message_provider.feature
@@ -139,6 +139,7 @@ Feature: Message provider
     Then the verification will NOT be successful
     And the verification results will contain a "Body had differences" error
 
+  @wip
   Scenario: Supports messages with body formatted for the Kafka schema registry
     Given a provider is started that can generate the "kafka" message with "file: kafka-body.xml"
     And a Pact file for "kafka":"file: kafka-expected-body.xml" is to be verified


### PR DESCRIPTION
This scenario is disabled in [pact-reference](https://github.com/pact-foundation/pact-reference/blob/master/compatibility-suite/pact-compatibility-suite/features/V3/message_provider.feature#L142-L146)

There is no implementation for it, and I not sure what is the correct way to implement it.

So I comment it out to help other languages.