### PR TITLE
fix: Interaction's comment should be string not array

### DIFF
--- a/features/V4/http_consumer.feature
+++ b/features/V4/http_consumer.feature
@@ -23,4 +23,4 @@ Feature: HTTP consumer
     Given an HTTP interaction is being defined for a consumer test
     And a comment "this is a comment" is added to the HTTP interaction
     When the Pact file for the test is generated
-    Then the first interaction in the Pact file will have "comments" = '{"text":["this is a comment"]}'
+    Then the first interaction in the Pact file will have "comments" = '{"text":"this is a comment"}'

--- a/features/V4/message_consumer.feature
+++ b/features/V4/message_consumer.feature
@@ -23,4 +23,4 @@ Feature: Message consumer
     Given a message interaction is being defined for a consumer test
     And a comment "this is a comment" is added to the message interaction
     When the Pact file for the test is generated
-    Then the first interaction in the Pact file will have "comments" = '{"text":["this is a comment"]}'
+    Then the first interaction in the Pact file will have "comments" = '{"text":"this is a comment"}'

--- a/features/V4/synchronous_message_consumer.feature
+++ b/features/V4/synchronous_message_consumer.feature
@@ -23,7 +23,7 @@ Feature: Synchronous Message consumer
     Given a synchronous message interaction is being defined for a consumer test
     And a comment "this is a comment" is added to the synchronous message interaction
     When the Pact file for the test is generated
-    Then the first interaction in the Pact file will have "comments" = '{"text":["this is a comment"]}'
+    Then the first interaction in the Pact file will have "comments" = '{"text":"this is a comment"}'
 
   Scenario: When all messages are successfully processed
     Given a synchronous message interaction is being defined for a consumer test


### PR DESCRIPTION
Currently I have to do this in pact-php to make the tests pass:

```php
$this->interaction->setComments(['text' => json_encode([$value])]);
```

I think it should be this:

```php
$this->interaction->setComments(['text' => $value]);
```

cc @JP-Ellis 