### PR TITLE
feat: use consistent fixture headers

### DIFF
--- a/features/V1/http_provider.feature
+++ b/features/V1/http_provider.feature
@@ -118,16 +118,16 @@ Feature: Basic HTTP provider
 
   Scenario: Verifies the response status code
     Given a provider is started that returns the response from interaction 1, with the following changes:
-      | status |
-      | 400    |
+      | response |
+      | 400      |
     And a Pact file for interaction 1 is to be verified
     When the verification is run
     Then the verification will NOT be successful
     And the verification results will contain a "Response status did not match" error
 
   Scenario: Verifies the response headers
-    Given a provider is started that returns the response from interaction 1, with the following changes:
-      | headers                 |
+    Given a provider is started that returns the response from interaction 5, with the following changes:
+      | response headers        |
       | 'X-TEST: Compatibility' |
     And a Pact file for interaction 5 is to be verified
     When the verification is run
@@ -142,7 +142,7 @@ Feature: Basic HTTP provider
 
   Scenario: Response with plain text body (negative case)
     Given a provider is started that returns the response from interaction 6, with the following changes:
-      | body                       |
+      | response body              |
       | Hello Compatibility Suite! |
     And a Pact file for interaction 6 is to be verified
     When the verification is run
@@ -157,7 +157,7 @@ Feature: Basic HTTP provider
 
   Scenario: Response with JSON body (negative case)
     Given a provider is started that returns the response from interaction 1, with the following changes:
-      | body                             |
+      | response body                    |
       | JSON: { "one": 100, "two": "b" } |
     And a Pact file for interaction 1 is to be verified
     When the verification is run
@@ -172,7 +172,7 @@ Feature: Basic HTTP provider
 
   Scenario: Response with XML body (negative case)
     Given a provider is started that returns the response from interaction 7, with the following changes:
-      | body                                                                      |
+      | response body                                                             |
       | XML: <?xml version="1.0" encoding="UTF-8" ?><values><one>A</one></values> |
     And a Pact file for interaction 7 is to be verified
     When the verification is run
@@ -187,7 +187,7 @@ Feature: Basic HTTP provider
 
   Scenario: Response with binary body (negative case)
     Given a provider is started that returns the response from interaction 8, with the following changes:
-      | body             |
+      | response body    |
       | file: spider.jpg |
     And a Pact file for interaction 8 is to be verified
     When the verification is run
@@ -202,7 +202,7 @@ Feature: Basic HTTP provider
 
   Scenario: Response with form post body (negative case)
     Given a provider is started that returns the response from interaction 9, with the following changes:
-      | body             |
+      | response body    |
       | a=1&b=2&c=33&d=4 |
     And a Pact file for interaction 9 is to be verified
     When the verification is run
@@ -217,7 +217,7 @@ Feature: Basic HTTP provider
 
   Scenario: Response with multipart body (negative case)
     Given a provider is started that returns the response from interaction 10, with the following changes:
-      | body                      |
+      | response body             |
       | file: multipart2-body.xml |
     And a Pact file for interaction 10 is to be verified
     When the verification is run

--- a/features/V2/http_provider.feature
+++ b/features/V2/http_provider.feature
@@ -10,15 +10,15 @@ Feature: Basic HTTP provider
 
   Scenario: Supports matching rules for the response headers (positive case)
     Given a provider is started that returns the response from interaction 1, with the following changes:
-      | headers        |
-      | 'X-TEST: 1000' |
+      | response headers |
+      | 'X-TEST: 1000'   |
     And a Pact file for interaction 1 is to be verified
     When the verification is run
     Then the verification will be successful
 
   Scenario: Supports matching rules for the response headers (negative case)
     Given a provider is started that returns the response from interaction 1, with the following changes:
-      | headers          |
+      | response headers |
       | 'X-TEST: 123ABC' |
     And a Pact file for interaction 1 is to be verified
     When the verification is run
@@ -27,7 +27,7 @@ Feature: Basic HTTP provider
 
   Scenario: Verifies the response body (positive case)
     Given a provider is started that returns the response from interaction 2, with the following changes:
-      | body                             |
+      | response body                      |
       | JSON: { "one": "100", "two": "b" } |
     And a Pact file for interaction 2 is to be verified
     When the verification is run
@@ -35,7 +35,7 @@ Feature: Basic HTTP provider
 
   Scenario: Verifies the response body (negative case)
     Given a provider is started that returns the response from interaction 2, with the following changes:
-      | body                             |
+      | response body                    |
       | JSON: { "one": 100, "two": "b" } |
     And a Pact file for interaction 2 is to be verified
     When the verification is run

--- a/features/V4/http_provider.feature
+++ b/features/V4/http_provider.feature
@@ -9,7 +9,7 @@ Feature: HTTP provider
 
   Scenario: Verifying a pending HTTP interaction
     Given a provider is started that returns the response from interaction 1, with the following changes:
-      | body              |
+      | response body              |
       | file: basic2.json |
     And a Pact file for interaction 1 is to be verified, but is marked pending
     When the verification is run


### PR DESCRIPTION
To avoid any risk of ambiguity, a few headers have been updated to clarify whether the change applies to the request or response.